### PR TITLE
Include JDK 21 at runtime

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,7 @@ parts:
       - kf5-5-106-qt-5-15-9-core22
       - kf5-5-106-qt-5-15-9-core22-sdk
     stage-packages:
+      - openjdk-21-jre
       - openjdk-17-jre
       - openjdk-8-jre
 


### PR DESCRIPTION
Java 21 is required for Minecraft 1.20.6 and above, as well as certain modpacks in older Minecraft versions. This change adds it, so that JDK 8, 17, and 21 are available at runtime.

Temporary workaround
---

For anyone looking for a temporary workaround before this change is merged:

```bash
cd ~/snap/prismlauncher/common
mkdir java
cd java
tar vxf $PATH_TO_YOUR_JDK
```

Replace `$PATH_TO_YOUR_JDK` with a path to a copy of Adoptium OpenJDK 21.

Then click `Auto-detect...` in the PrismLauncher UI to select it.