### PR TITLE
add env var PRISMLAUNCHER_DATA_DIR

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,8 @@ apps:
     command: usr/bin/prismlauncher
     extensions:
       - kde-neon
+    environment:
+      PRISMLAUNCHER_DATA_DIR: "$SNAP_USER_COMMON/PrismLauncher"
     plugs:
       - home
       - opengl


### PR DESCRIPTION
This tells PrismLauncher to put its data in a subdir of $SNAP_USER_COMMON rather than directly in $SNAP_USER_COMMON.

This will not migrate existing user data, but seeing as this snap is still on the edge branch, this should not matter.

Edit: To clarify, this env var was introduced in 9.0, so it will not do anything in 8.4.