### PR TITLE
fix: replace prism discord link

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ website: https://prismlauncher.org/
 source-code: https://github.com/PrismLauncher/PrismLauncher
 issues: https://github.com/PrismLauncher/PrismLauncher/issues
 donation: https://opencollective.com/prismlauncher
-contact: https://discord.gg/prismlauncher
+contact: https://prismlauncher.org/discord
 summary: A custom Minecraft launcher with modpack support
 adopt-info: prismlauncher
 


### PR DESCRIPTION
we lost the old vanity a long time ago now and apparently it was taken by account stealers